### PR TITLE
Add fail_if_missing flag (default true) for data sync

### DIFF
--- a/src/aibs_informatics_core/models/data_sync.py
+++ b/src/aibs_informatics_core/models/data_sync.py
@@ -102,6 +102,7 @@ class DataSyncConfig(SchemaModel):
     require_lock: bool = custom_field(default=False, mm_field=BooleanField())
     force: bool = custom_field(default=False, mm_field=BooleanField())
     size_only: bool = custom_field(default=False, mm_field=BooleanField())
+    fail_if_missing: bool = custom_field(default=True, mm_field=BooleanField())
 
 
 @dataclass


### PR DESCRIPTION
## What's in this Change?

add support for `fail_if_missing` flag. this is to configure whether to explicitly fail data sync if the source data does not exist. 


