### PR TITLE
Fix EnvBaseMixins issues when subclassing with other generics

### DIFF
--- a/src/aibs_informatics_core/env.py
+++ b/src/aibs_informatics_core/env.py
@@ -223,7 +223,9 @@ class EnvBaseMixinsBase(Generic[E]):
 
 
 class EnvBaseMixins(EnvBaseMixinsBase[EnvBase]):
-    pass
+    @classmethod
+    def _env_base_class(cls) -> Type[EnvBase]:
+        return EnvBase
 
 
 class EnvBaseEnumMixins:


### PR DESCRIPTION
## Details
fixes an issue in aibs-informatics-aws-lambda 

```
env_base = None, env_base_class = <class 'aibs_informatics_aws_lambda.handlers.demand.model.PrepareDemandScaffoldingRequest'>

    def get_env_base(
        env_base: Optional[Union[str, E]] = None,
        env_base_class: Optional[Type[Union[E, EnvBase]]] = None,
    ) -> Union[E, EnvBase]:
        """Will look for the env_base as an environment variable."""
        env_base_cls: Type[E] = env_base_class or EnvBase  # type: ignore[assignment]
        if env_base:
            if isinstance(env_base, env_base_cls):
                return env_base
            else:
                return env_base_cls(env_base)
>       return env_base_cls.from_env()
E       AttributeError: type object 'PrepareDemandScaffoldingRequest' has no attribute 'from_env'

```
