### PR TITLE
Add extra logic for OSError (stale file handle)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
             make release            
           else
             # Install dependencies
-            uv sync --frozen --group all --all-extras --resolution ${{ matrix.uv-resolution }}
+            uv sync --frozen --group dev --all-extras --resolution ${{ matrix.uv-resolution }}
             
             # Linting 
             uv run ruff check

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ test: pytest  ## Run Standard Tests
 ##@ Inspect Commands
 #####################
 
-coverage-server: $(INSTALL_STAMP) ## Run coverage server
+coverage-server: .uv ## Run coverage server
 	$(PYTHON) -m http.server $(COVERAGE_SERVER_PORT) -d $(COVERAGE_DIR)
 
 .PHONY: coverage-server

--- a/src/aibs_informatics_core/executors/base.py
+++ b/src/aibs_informatics_core/executors/base.py
@@ -190,7 +190,7 @@ class BaseExecutor(EnvBaseMixins, PostInitMixin, Generic[REQUEST, RESPONSE]):
             local_path.parent.exists() and not os.access(local_path.parent, os.W_OK)
         ):
             raise ValueError(
-                f"local path specified {local_path} cannot be written to. " f"Must be a file "
+                f"local path specified {local_path} cannot be written to. Must be a file "
             )
         local_path.parent.mkdir(parents=True, exist_ok=True)
         local_path.write_text(json.dumps(output, sort_keys=True))

--- a/src/aibs_informatics_core/models/demand_execution/model.py
+++ b/src/aibs_informatics_core/models/demand_execution/model.py
@@ -59,4 +59,4 @@ class DemandExecution(SchemaModel):
         The execution name is prefixed by demand Id to be more easily discoverable
 
         """
-        return f'{self.execution_id}-{get_current_time().strftime("%Y%m%dT%H%M%S")}'
+        return f"{self.execution_id}-{get_current_time().strftime('%Y%m%dT%H%M%S')}"

--- a/src/aibs_informatics_core/models/demand_execution/parameters.py
+++ b/src/aibs_informatics_core/models/demand_execution/parameters.py
@@ -130,8 +130,7 @@ class DemandExecutionParameters(SchemaModel):
         missing_param_envnames = set(inp_envnames).union(out_envnames).difference(param_map.keys())
         if len(missing_param_envnames) > 0:
             raise ValidationError(
-                f"Batch Job inputs/outputs not found in param envnames: "
-                f"{missing_param_envnames}"
+                f"Batch Job inputs/outputs not found in param envnames: {missing_param_envnames}"
             )
 
     def _validate_param_pairs(self):
@@ -142,7 +141,7 @@ class DemandExecutionParameters(SchemaModel):
         diff = all_input_output_set.difference(set(self.inputs).union(set(self.outputs)))
         if len(diff) > 0:
             raise ValidationError(
-                "input_output_mapping contained value(s) not found in params: " f"{diff}"
+                f"input_output_mapping contained value(s) not found in params: {diff}"
             )
 
         # Validate no duplicate output sets
@@ -155,7 +154,7 @@ class DemandExecutionParameters(SchemaModel):
                 seen.add(s.outputs)
         if len(duplicate_output_sets) > 0:
             raise ValidationError(
-                "Duplicate output set(s) in input_output_map: " f"{duplicate_output_sets}"
+                f"Duplicate output set(s) in input_output_map: {duplicate_output_sets}"
             )
 
     @refresh_params(force=False)

--- a/src/aibs_informatics_core/utils/file_operations.py
+++ b/src/aibs_informatics_core/utils/file_operations.py
@@ -251,13 +251,25 @@ def copy_path(source_path: Path, destination_path: Path, exists_ok: bool = False
         shutil.copytree(source_path, destination_path, dirs_exist_ok=exists_ok)
 
 
-def remove_path(path: Path):
+def remove_path(path: Path, ignore_errors: bool = True):
     """Removes the contents at the path, if it exists"""
-    if path.exists():
-        if path.is_dir():
-            shutil.rmtree(path)
+    try:
+        if path.exists():
+            if path.is_dir():
+                shutil.rmtree(path, ignore_errors=ignore_errors)
+            else:
+                os.remove(path)
+    except FileNotFoundError as e:
+        # Ignore errors if requested
+        if not ignore_errors:
+            raise e
+    except OSError as ose:
+        # Ignore errors if requested
+        if not ignore_errors:
+            raise ose
         else:
-            os.remove(path)
+            logger.warning(f"Failed to remove path {path}. Reason: {ose}")
+            return
 
 
 def get_path_size_bytes(path: Path) -> int:

--- a/src/aibs_informatics_core/utils/file_operations.py
+++ b/src/aibs_informatics_core/utils/file_operations.py
@@ -274,9 +274,13 @@ def get_path_size_bytes(path: Path) -> int:
         except OSError as ose:
             if ose.errno == errno.ESTALE:
                 logger.warning(f"{ose} raised for {file_path}.")
-                if path.exists():
-                    logger.warning(f"Adding {path} to end of list to check later.")
-                    file_paths.append(file_path)
+                try:
+                    if Path(str(path)).exists():
+                        logger.warning(f"Adding {path} to end of list to check later.")
+                        file_paths.append(file_path)
+                except (FileNotFoundError, OSError) as fall_back_e:
+                    logger.warning(f"Failed to check if path {path} exists: {fall_back_e}")
+                    continue
             else:
                 logger.error(f"Unexpected error raised for {path}. Reason: {ose}")
                 raise ose

--- a/test/aibs_informatics_core/utils/test_file_operations.py
+++ b/test/aibs_informatics_core/utils/test_file_operations.py
@@ -354,6 +354,21 @@ class FileOperationsTests(FileOperationsBaseTest):
         self.assertTrue(new_path.exists())
         self.assertDirectoryContents(new_path, ["a", "b"])
 
+    def test__remove_path__raises_error_when_ignore_errors_false(self):
+        path = MagicMock()
+
+        # Test for OSError
+        path.exists.side_effect = OSError()
+        remove_path(path, ignore_errors=True)
+        with self.assertRaises(OSError):
+            remove_path(path, ignore_errors=False)
+
+        # Test for FileNotFoundError
+        path.exists.side_effect = FileNotFoundError()
+        remove_path(path, ignore_errors=True)
+        with self.assertRaises(FileNotFoundError):
+            remove_path(path, ignore_errors=False)
+
     def test__remove_path__handles_file(self):
         path = self.tmp_file()
         path.write_text("_" * 5)

--- a/test/aibs_informatics_core/utils/test_file_operations.py
+++ b/test/aibs_informatics_core/utils/test_file_operations.py
@@ -259,22 +259,31 @@ class FileOperationsTests(FileOperationsBaseTest):
     def test__get_path_size_bytes__handles_errors(self, mock_Path, mock_find_all_paths):
         mock_find_all_paths.return_value = ["a", "b"]
         path = self.tmp_path()
-        e1 = MagicMock()
-        e1.stat.side_effect = FileNotFoundError()
-        e2 = MagicMock()
+        # first constructed path outside of try-except clause
+        p1 = MagicMock()
+        p1.stat.side_effect = FileNotFoundError()
+        # second constructed path outside of try-except clause
+        # will reuse twice over
+        p2 = MagicMock()
         ose = OSError()
         ose.errno = errno.ESTALE
-        e2.stat.side_effect = ose
+        p2.stat.side_effect = ose
+        # first constructed path in except clause
+        p3 = MagicMock()
+        p3.exists.return_value = True
+        # Second constructed path in except clause
+        p4 = MagicMock()
+        # This tests the nested exception handling
+        p4.exists.side_effect = ose
 
-        e2.exists.side_effect = [True, False]
-        mock_Path.side_effect = [e1, e2, e2]
+        mock_Path.side_effect = [p1, p2, p3, p2, p4]
         self.assertEqual(get_path_size_bytes(path), 0)
 
         with self.assertRaises(OSError):
             ose.errno = errno.ETIME
-            e1.stat.side_effect = ose
+            p1.stat.side_effect = ose
             mock_find_all_paths.return_value = ["a"]
-            mock_Path.side_effect = [e1]
+            mock_Path.side_effect = [p1]
             get_path_size_bytes(path)
 
     def test__move_path__handles_file(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,9 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 
 [[package]]
 name = "aibs-informatics-core"
-version = "0.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "dataclasses-json" },
@@ -57,6 +57,7 @@ requires-dist = [
     { name = "requests" },
     { name = "typing-inspect" },
 ]
+provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 build = [


### PR DESCRIPTION
- **enhance error handling in get_path_size_bytes to check path existence safely**
- **refactor error messages for clarity and consistency; update uv.lock for development extras**

## What's in this Change?

We get the following transient error when there are distributed tasks trying to remove the same path. 

```
Traceback (most recent call last):
--
File "/var/task/bin/handle-lambda-request", line 8, in <module>
sys.exit(handle_cli())
File "/var/task/aibs_informatics_aws_lambda/main.py", line 111, in handle_cli
response = target_handler(event, DefaultLambdaContext())
File "/var/task/aws_lambda_powertools/logging/logger.py", line 450, in decorate
return lambda_handler(event, context, *args, **kwargs)
File "/var/task/aibs_informatics_aws_lambda/common/handler.py", line 82, in handler
response = lambda_handler.handle(request=request)
File "/var/task/aibs_informatics_aws_lambda/handlers/data_sync/file_system.py", line 148, in handle
remove_path(path)
File "/var/task/aibs_informatics_core/utils/file_operations.py", line 258, in remove_path
shutil.rmtree(path)
File "/var/lang/lib/python3.9/shutil.py", line 734, in rmtree
_rmtree_safe_fd(fd, path, onerror)
File "/var/lang/lib/python3.9/shutil.py", line 667, in _rmtree_safe_fd
_rmtree_safe_fd(dirfd, fullname, onerror)
File "/var/lang/lib/python3.9/shutil.py", line 667, in _rmtree_safe_fd
_rmtree_safe_fd(dirfd, fullname, onerror)
File "/var/lang/lib/python3.9/shutil.py", line 667, in _rmtree_safe_fd
_rmtree_safe_fd(dirfd, fullname, onerror)
File "/var/lang/lib/python3.9/shutil.py", line 663, in _rmtree_safe_fd
onerror(os.open, fullname, sys.exc_info())
File "/var/lang/lib/python3.9/shutil.py", line 660, in _rmtree_safe_fd
dirfd = os.open(entry.name, os.O_RDONLY, dir_fd=topfd)
OSError: [Errno 116] Stale file handle: 'xxx'
```

Adding os error handling in a few places.  

Also adding more tests to improve test coverage. 

