### PR TITLE
feature/DT 7737 add execution tags to demand execution

### DIFF
--- a/src/aibs_informatics_core/models/demand_execution/metadata.py
+++ b/src/aibs_informatics_core/models/demand_execution/metadata.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from aibs_informatics_core.models.aws.sfn import ExecutionArn
-from aibs_informatics_core.models.base import SchemaModel, custom_field
+from aibs_informatics_core.models.base import SchemaModel, custom_field, pre_load
 from aibs_informatics_core.models.base.custom_fields import (
     BooleanField,
     CustomStringField,
@@ -20,7 +20,10 @@ class DemandExecutionMetadata(SchemaModel):
     arn: Optional[ExecutionArn] = custom_field(
         mm_field=CustomStringField(ExecutionArn), default=None
     )
-    tag: Optional[str] = custom_field(default=None)
+    tags: Optional[Dict[str, str]] = custom_field(
+        mm_field=DictField(StringField(), StringField(), allow_none=True),
+        default=None,
+    )
     notify_on: Optional[Dict[Status, bool]] = custom_field(
         mm_field=DictField(keys=EnumField(Status), values=BooleanField(), allow_none=True),
         default=None,
@@ -29,3 +32,62 @@ class DemandExecutionMetadata(SchemaModel):
         mm_field=ListField(StringField(), allow_none=True),
         default=None,
     )
+
+    @property
+    def tag(self) -> Optional[str]:
+        """Return all tags as a comma separated string if available.
+
+        Example:
+            >>> metadata = DemandExecutionMetadata(tags={"key": "value"})
+            >>> metadata.tag
+            'key=value'
+            >>> metadata = DemandExecutionMetadata(tags={"key": "key"})
+            >>> metadata.tag
+            'key'
+            >>> metadata = DemandExecutionMetadata(tags={"flag": "flag", "key": "value"})
+            >>> metadata.tag
+            'flag,key=value'
+            >>> metadata = DemandExecutionMetadata(tags={})
+            >>> metadata.tag
+            None
+
+        Returns:
+            Optional[str]: Comma separated string of tags or None if no tags are available.
+
+        """
+        if self.tags:
+            return ",".join([f"{k}={v}" if k != v else k for k, v in self.tags.items()])
+        return None
+
+    @classmethod
+    @pre_load
+    def sanitize_tags(cls, data: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+        norm_tags: dict[str, str] = {}
+        if "tag" in data:
+            tag = data.pop("tag")
+            if isinstance(tag, (str, int)):
+                norm_tags = {str(tag): str(tag)} | norm_tags
+            elif isinstance(tag, list):
+                norm_tags = {str(t): str(t) for t in tag} | norm_tags
+
+        if "tags" in data:
+            tags = data["tags"]
+            if isinstance(tags, (str, int)):
+                tags = dict(
+                    [
+                        (tag_part, tag_part)
+                        if "=" not in tag_part
+                        else cast(tuple[str, str], tuple(tag_part.split("=", 1)))
+                        for tag_part in str(tags).split(",")
+                    ]
+                )
+                data["tags"] = norm_tags | tags
+            elif isinstance(tags, list):
+                data["tags"] = norm_tags | {str(tag): str(tag) for tag in tags}
+            elif isinstance(tags, dict):
+                data["tags"] = norm_tags | tags
+            else:
+                raise ValueError(f"Invalid tags format: {tags}")
+        elif norm_tags:
+            data["tags"] = norm_tags
+        return data

--- a/src/aibs_informatics_core/models/demand_execution/metadata.py
+++ b/src/aibs_informatics_core/models/demand_execution/metadata.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import logging
 from typing import Any, Dict, List, Optional, cast
 
 from aibs_informatics_core.models.aws.sfn import ExecutionArn
@@ -62,32 +63,50 @@ class DemandExecutionMetadata(SchemaModel):
     @classmethod
     @pre_load
     def sanitize_tags(cls, data: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+        """Sanitize tags and tag fields in the input data.
+
+        If the `tag` field is present, it will be converted to a dictionary format. It supports
+        both string and list formats. `tag` can include multiple tags separated by commas.
+
+        By contrast, the `tags` field is expected to be a dictionary. If both `tag` and `tags` are
+        present, they will be merged, with `tags` taking precedence.
+
+        The `tag` field is deprecated and will be removed in a future version. It is recommended to
+        use the `tags` field exclusively for tagging.
+
+        TODO: Once we have datafixes for the places where demand execution metadata is used, we
+        can remove this method and the `tag` field from the model. The `tags` field should be used
+        exclusively.
+
+        """
         norm_tags: dict[str, str] = {}
         if "tag" in data:
-            tag = data.pop("tag")
-            if isinstance(tag, (str, int)):
-                norm_tags = {str(tag): str(tag)} | norm_tags
-            elif isinstance(tag, list):
-                norm_tags = {str(t): str(t) for t in tag} | norm_tags
+            tag_value = data.pop("tag")
+            if isinstance(tag_value, (str, int)):
+                tag_value = [tag_value]
 
-        if "tags" in data:
-            tags = data["tags"]
-            if isinstance(tags, (str, int)):
-                tags = dict(
+            if isinstance(tag_value, list) and all([isinstance(_, (str, int)) for _ in tag_value]):
+                norm_tags = dict(
                     [
                         (tag_part, tag_part)
                         if "=" not in tag_part
                         else cast(tuple[str, str], tuple(tag_part.split("=", 1)))
-                        for tag_part in str(tags).split(",")
+                        for _ in tag_value
+                        for tag_part in str(_).split(",")
                     ]
                 )
-                data["tags"] = norm_tags | tags
-            elif isinstance(tags, list):
-                data["tags"] = norm_tags | {str(tag): str(tag) for tag in tags}
-            elif isinstance(tags, dict):
+            else:
+                logging.warning(
+                    f"Invalid tag format ({type(tag_value)}): {tag_value}. "
+                    "Expected str, int, or list of str/int. Ignoring."
+                )
+
+        if "tags" in data:
+            tags = data["tags"]
+            if isinstance(tags, dict):
                 data["tags"] = norm_tags | tags
             else:
-                raise ValueError(f"Invalid tags format: {tags}")
+                raise ValueError(f"Invalid tags format ({type(tags)}): {tags}")
         elif norm_tags:
             data["tags"] = norm_tags
         return data

--- a/test/aibs_informatics_core/models/api/test_route.py
+++ b/test/aibs_informatics_core/models/api/test_route.py
@@ -10,6 +10,7 @@ from aibs_informatics_core.models.api.route import (
     API_SERVICE_LOG_LEVEL_ENV_VAR,
     API_SERVICE_LOG_LEVEL_KEY,
     CLIENT_VERSION_KEY,
+    ApiClientInterface,
     ApiRequestConfig,
     ApiRoute,
 )
@@ -344,8 +345,16 @@ class ApiRouteTests(BaseTest):
         self.assertEqual(GetterResourceRoute.get_client_method_name(), "getter_resource")
 
     def test__create_client_method__works(self):
-        # just testing that I can call it without error
-        GetterResourceRoute.create_route_method()
+        class TestClient(ApiClientInterface):
+            getter_resource = GetterResourceRoute.create_route_method()
+
+            def call(self, route, request):
+                assert isinstance(request, BaseRequest)
+                response = route.get_response_cls()
+                return response.from_dict({"any_str": "response"})
+
+        response = TestClient().getter_resource(BaseRequest(id_str="imanid"))
+        self.assertEqual(response.any_str, "response")
 
     def test__repr__works(self):
         self.assertEqual(

--- a/test/aibs_informatics_core/models/demand_execution/test_metadata.py
+++ b/test/aibs_informatics_core/models/demand_execution/test_metadata.py
@@ -73,6 +73,36 @@ from aibs_informatics_core.models.status import Status
         param(
             {
                 "tag": ["key1", "key2"],
+            },
+            DemandExecutionMetadata(
+                tags={"key1": "key1", "key2": "key2"},
+            ),
+            does_not_raise(),
+            id="usage of old tag field as list",
+        ),
+        param(
+            {
+                "tag": "key1,key2",
+            },
+            DemandExecutionMetadata(
+                tags={"key1": "key1", "key2": "key2"},
+            ),
+            does_not_raise(),
+            id="usage of old tag field as str of comma separated key-only tags",
+        ),
+        param(
+            {
+                "tag": "key1,key2=value2",
+            },
+            DemandExecutionMetadata(
+                tags={"key1": "key1", "key2": "value2"},
+            ),
+            does_not_raise(),
+            id="usage of old tag field as str of comma separated key-only tags",
+        ),
+        param(
+            {
+                "tag": ["key1", "key2"],
                 "tags": {"key1": "value1", "key2": "value2"},
             },
             DemandExecutionMetadata(
@@ -83,45 +113,23 @@ from aibs_informatics_core.models.status import Status
         ),
         param(
             {
-                "tags": ["key1", "key2"],
-            },
-            DemandExecutionMetadata(
-                tags={"key1": "key1", "key2": "key2"},
-            ),
-            does_not_raise(),
-            id="tags field as list",
-        ),
-        param(
-            {
-                "tags": "key1,key2",
-            },
-            DemandExecutionMetadata(
-                tags={"key1": "key1", "key2": "key2"},
-            ),
-            does_not_raise(),
-            id="tags field as str of comma separated key-only tags",
-        ),
-        param(
-            {
-                "tags": "key1,key2=value2",
-            },
-            DemandExecutionMetadata(
-                tags={"key1": "key1", "key2": "value2"},
-            ),
-            does_not_raise(),
-            id="tags field as str of comma separated key-only tags",
-        ),
-        param(
-            {
                 "tag": ValueError("Invalid tags format: 123"),
             },
             DemandExecutionMetadata(),
             does_not_raise(),
-            id="invalid old tag field ignored",
+            id="invalid type old tag field ignored",
         ),
         param(
             {
-                "tags": ValueError("Invalid tags format: 123"),
+                "tag": ["key1", "key2", ValueError("Invalid tags format: 123")],
+            },
+            DemandExecutionMetadata(),
+            does_not_raise(),
+            id="invalid nested types of old tag field ignored",
+        ),
+        param(
+            {
+                "tags": "tag",
             },
             None,
             raises(ValueError),

--- a/test/aibs_informatics_core/models/demand_execution/test_metadata.py
+++ b/test/aibs_informatics_core/models/demand_execution/test_metadata.py
@@ -1,0 +1,151 @@
+from typing import Any, Optional
+
+from aibs_informatics_test_resources import does_not_raise
+
+from pytest import mark, param, raises
+
+from aibs_informatics_core.models.demand_execution.metadata import DemandExecutionMetadata
+from aibs_informatics_core.models.aws.sfn import ExecutionArn
+from aibs_informatics_core.models.status import Status
+
+
+@mark.parametrize(
+    "data, expected, raise_expectation",
+    [
+        param(
+            {
+                "user": "test_user",
+                "arn": "arn:aws:states:us-west-2:123456789012:execution:my-execution:1234567890",
+                "tags": {"key1": "value1", "key2": "value2"},
+                "notify_on": {"COMPLETED": True, "FAILED": False},
+                "notify_list": [],
+            },
+            DemandExecutionMetadata(
+                user="test_user",
+                arn=ExecutionArn(
+                    "arn:aws:states:us-west-2:123456789012:execution:my-execution:1234567890"
+                ),
+                tags={"key1": "value1", "key2": "value2"},
+                notify_on={Status.COMPLETED: True, Status.FAILED: False},
+                notify_list=[],
+            ),
+            does_not_raise(),
+            id="full",
+        ),
+        param(
+            {},
+            DemandExecutionMetadata(),
+            does_not_raise(),
+            id="empty",
+        ),
+        param(
+            {
+                "tag": "key",
+            },
+            DemandExecutionMetadata(
+                tags={"key": "key"},
+            ),
+            does_not_raise(),
+            id="usage of old tag field as str",
+        ),
+        param(
+            {
+                "tag": "key",
+                "tags": {"key1": "value1", "key2": "value2"},
+            },
+            DemandExecutionMetadata(
+                tags={"key": "key", "key1": "value1", "key2": "value2"},
+            ),
+            does_not_raise(),
+            id="usage of old tag field as str and new tags field",
+        ),
+        param(
+            {
+                "tag": ["key_1", "key_2"],
+                "tags": {"key1": "value1", "key2": "value2"},
+            },
+            DemandExecutionMetadata(
+                tags={"key_1": "key_1", "key_2": "key_2", "key1": "value1", "key2": "value2"},
+            ),
+            does_not_raise(),
+            id="usage of old tag field as list and new tags field",
+        ),
+        param(
+            {
+                "tag": ["key1", "key2"],
+                "tags": {"key1": "value1", "key2": "value2"},
+            },
+            DemandExecutionMetadata(
+                tags={"key1": "value1", "key2": "value2"},
+            ),
+            does_not_raise(),
+            id="old tags overwritten by new tags",
+        ),
+        param(
+            {
+                "tags": ["key1", "key2"],
+            },
+            DemandExecutionMetadata(
+                tags={"key1": "key1", "key2": "key2"},
+            ),
+            does_not_raise(),
+            id="tags field as list",
+        ),
+        param(
+            {
+                "tags": "key1,key2",
+            },
+            DemandExecutionMetadata(
+                tags={"key1": "key1", "key2": "key2"},
+            ),
+            does_not_raise(),
+            id="tags field as str of comma separated key-only tags",
+        ),
+        param(
+            {
+                "tags": "key1,key2=value2",
+            },
+            DemandExecutionMetadata(
+                tags={"key1": "key1", "key2": "value2"},
+            ),
+            does_not_raise(),
+            id="tags field as str of comma separated key-only tags",
+        ),
+        param(
+            {
+                "tag": ValueError("Invalid tags format: 123"),
+            },
+            DemandExecutionMetadata(),
+            does_not_raise(),
+            id="invalid old tag field ignored",
+        ),
+        param(
+            {
+                "tags": ValueError("Invalid tags format: 123"),
+            },
+            None,
+            raises(ValueError),
+            id="invalid tags field raises error",
+        ),
+    ],
+)
+def test__DemandExecutionMetadata__from_dict(
+    data: dict[str, Any], expected: Optional[DemandExecutionMetadata], raise_expectation
+):
+    """Test the from_dict method of DemandExecutionMetadata."""
+    with raise_expectation:
+        metadata = DemandExecutionMetadata.from_dict(data)
+    if expected:
+        assert metadata == expected
+
+
+def test__DemandExecutionMetadata__tag__works():
+    """Test the tag property of DemandExecutionMetadata."""
+    metadata = DemandExecutionMetadata(tags={"key": "value"})
+    assert metadata.tag == "key=value"
+    metadata = DemandExecutionMetadata(tags={"key": "key"})
+    assert metadata.tag == "key"
+    metadata = DemandExecutionMetadata(tags={"flag": "flag", "key": "value"})
+    assert metadata.tag == "flag,key=value"
+    metadata = DemandExecutionMetadata(tags={})
+    assert metadata.tag is None

--- a/test/aibs_informatics_core/utils/tools/test_strtools.py
+++ b/test/aibs_informatics_core/utils/tools/test_strtools.py
@@ -1,8 +1,10 @@
 from aibs_informatics_core.utils.tools.strtools import (
     is_prefixed,
     is_suffixed,
+    lowercase,
     removeprefix,
     removesuffix,
+    uppercase,
 )
 
 
@@ -16,6 +18,16 @@ def test__is_suffixed__works():
     assert not is_suffixed("v1", "v")
     assert is_suffixed("v1", "v1")
     assert is_suffixed("1v1", "v1")
+
+
+def test__lowercase__works():
+    assert lowercase("v1") == "v1"
+    assert lowercase("V1") == "v1"
+
+
+def test__uppercase__works():
+    assert uppercase("v1") == "V1"
+    assert uppercase("V1") == "V1"
 
 
 def test__removeprefix__works():


### PR DESCRIPTION
## What's in this Change?

Primary goal is to introduce a new field for key-value tags in the `DemandExecution.metadata.tags` (in `DemandExecutionMetadata.tags`) model. This will be used downstream in cdk lib to add tagging to resources used to run the demand. 

I have also added additional tests to increase total test coverage. 

related to https://github.com/AllenInstitute/aibs-informatics-cdk-lib/pull/36
