### PR TITLE
Fix S3Path.is_valid() method

### DIFF
--- a/src/aibs_informatics_core/models/aws/s3.py
+++ b/src/aibs_informatics_core/models/aws/s3.py
@@ -189,6 +189,7 @@ class S3Path(ValidatedStr):
 
     @classmethod
     def _sanitize(cls, value: str, *args, **kwargs) -> str:
+        value = str(value)
         value = value[:3] + _DOUBLE_SLASH_PATTERN.sub(r"\1", value[3:])
         return value
 

--- a/test/aibs_informatics_core/models/aws/test_s3.py
+++ b/test/aibs_informatics_core/models/aws/test_s3.py
@@ -803,3 +803,41 @@ def test__S3Path__parent__works():
     # Test with just the bucket
     path = S3Path("s3://my-bucket/")
     assert path.parent == S3Path("s3://my-bucket/")  # Parent of bucket is itself
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_result",
+    [
+        pytest.param(
+            # input_value
+            "s3://my-bucket/my-prefix/my-key",
+            # expected_result
+            True,
+            id="Valid str as input"
+        ),
+        pytest.param(
+            # input_value
+            S3Path("s3://my-bucket/my-prefix/my-key"),
+            # expected_result
+            True,
+            id="Valid S3Path as input"
+        ),
+        pytest.param(
+            # input_value
+            Path("/some/file-system/path"),
+            # expected_result
+            False,
+            id="Regression test - `is_valid()` should handle Any input [Path]"
+        ),
+        pytest.param(
+            # input_value
+            3,
+            # expected_result
+            False,
+            id="`is_valid()` should handle Any input [int]"
+        )
+    ]
+)
+def test__S3Path__is_valid__works(input_value, expected_result):
+    result = S3Path.is_valid(value=input_value)
+    assert expected_result == result


### PR DESCRIPTION
Other devs in the Marmot team often use the S3Path.is_valid() method by providing non-string inputs as part of a type narrowing operation like so:

     """Ensure path is either a valid S3 URI or a pathlib.Path."""
     if S3Path.is_valid(value=value):
        return S3Path(value)
     elif isinstance(value, Path):
        return value
     else:
        raise ValueError("path must be an S3 URI or a pathlib.Path")

This commit fixes oversights that was preventing `is_valid()` from working properly when non-string types were being provided to it.