### PR TITLE
Add utility function to convert datetime to Zulu ISO 8601 format and corresponding tests

### DIFF
--- a/src/aibs_informatics_core/utils/time.py
+++ b/src/aibs_informatics_core/utils/time.py
@@ -3,9 +3,11 @@ __all__ = [
     "get_current_time",
     "get_duration_in_secs",
     "from_isoformat_8601",
+    "to_zulu_isoformat_8601",
 ]
 
 import datetime as dt
+from typing import Literal
 
 BEGINNING_OF_TIME = dt.datetime.fromtimestamp(0.0, tz=dt.timezone.utc)
 
@@ -60,17 +62,38 @@ def from_isoformat_8601(iso8601_str: str) -> dt.datetime:
         fmt = fmt + "%z"
     elif iso8601_str[-1] == "Z":
         fmt = fmt + "Z"
-    return dt.datetime.strptime(iso8601_str, fmt)
+    result = dt.datetime.strptime(iso8601_str, fmt)
+    # strptime treats 'Z' as a literal, producing a naive datetime.
+    # Since Z unambiguously means UTC, attach the UTC tzinfo.
+    if result.tzinfo is None and iso8601_str[-1] == "Z":
+        result = result.replace(tzinfo=dt.timezone.utc)
+    return result
 
 
-def to_zulu_isoformat_8601(value: dt.datetime | str) -> str:
-    """Convert a datetime object to a Zulu ISO 8601 formatted string.
+def to_zulu_isoformat_8601(
+    value: dt.datetime | str,
+    naive_handling: Literal["coerce", "error"] = "coerce",
+) -> str:
+    """Convert a datetime object or ISO 8601 string to a Zulu ISO 8601 formatted string.
 
     Args:
-        dt_obj (dt.datetime): The datetime object to convert.
+        value: The datetime object or ISO 8601 string to convert.
+        naive_handling: How to handle naive (timezone-unaware) datetimes.
+            ``"coerce"`` (default) treats them as UTC.
+            ``"error"`` raises a :class:`ValueError`.
 
     Returns:
-        str: The Zulu ISO 8601 formatted string.
+        The Zulu ISO 8601 formatted string.
+
+    Raises:
+        ValueError: If *naive_handling* is ``"error"`` and the datetime is naive.
     """
     dt_obj = from_isoformat_8601(value) if isinstance(value, str) else value
+    if dt_obj.tzinfo is None:
+        if naive_handling == "error":
+            raise ValueError(
+                "Naive datetime provided but naive_handling='error'. "
+                "Supply a timezone-aware datetime or use naive_handling='coerce'."
+            )
+        dt_obj = dt_obj.replace(tzinfo=dt.timezone.utc)
     return dt_obj.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")

--- a/src/aibs_informatics_core/utils/time.py
+++ b/src/aibs_informatics_core/utils/time.py
@@ -61,3 +61,16 @@ def from_isoformat_8601(iso8601_str: str) -> dt.datetime:
     elif iso8601_str[-1] == "Z":
         fmt = fmt + "Z"
     return dt.datetime.strptime(iso8601_str, fmt)
+
+
+def to_zulu_isoformat_8601(value: dt.datetime | str) -> str:
+    """Convert a datetime object to a Zulu ISO 8601 formatted string.
+
+    Args:
+        dt_obj (dt.datetime): The datetime object to convert.
+
+    Returns:
+        str: The Zulu ISO 8601 formatted string.
+    """
+    dt_obj = from_isoformat_8601(value) if isinstance(value, str) else value
+    return dt_obj.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")

--- a/test/aibs_informatics_core/utils/test_time.py
+++ b/test/aibs_informatics_core/utils/test_time.py
@@ -17,7 +17,7 @@ from test.base import does_not_raise
         ),
         param(
             "2022-06-09T06:58:14Z",
-            dt.datetime(2022, 6, 9, 6, 58, 14),
+            dt.datetime(2022, 6, 9, 6, 58, 14, tzinfo=dt.timezone.utc),
             does_not_raise(),
             id="VALID no microseconds, Z timezone",
         ),
@@ -35,7 +35,7 @@ from test.base import does_not_raise
         ),
         param(
             "2022-06-09T06:58:14.000Z",
-            dt.datetime(2022, 6, 9, 6, 58, 14),
+            dt.datetime(2022, 6, 9, 6, 58, 14, tzinfo=dt.timezone.utc),
             does_not_raise(),
             id="VALID with microseconds, Z timezone",
         ),
@@ -67,6 +67,11 @@ def test__from_isoformat_8601__works_as_expected(
             dt.datetime(2022, 6, 9, 6, 58, 14, tzinfo=dt.timezone.utc),
             "2022-06-09T06:58:14+00:00".replace("+00:00", "Z"),
             id="UTC datetime",
+        ),
+        param(
+            dt.datetime(2022, 6, 9, 6, 58, 14),
+            "2022-06-09T06:58:14+00:00".replace("+00:00", "Z"),
+            id="naive datetime assumed UTC",
         ),
         param(
             dt.datetime(2022, 6, 9, 6, 58, 14, 500000, tzinfo=dt.timezone.utc),
@@ -106,7 +111,28 @@ def test__from_isoformat_8601__works_as_expected(
             "2022-06-09T06:58:14+00:00".replace("+00:00", "Z"),
             id="string input with microseconds and +00:00 offset",
         ),
+        param(
+            "2022-06-09T06:58:14Z",
+            "2022-06-09T06:58:14+00:00".replace("+00:00", "Z"),
+            id="string input with Z suffix",
+        ),
+        param(
+            "2022-06-09T06:58:14.000Z",
+            "2022-06-09T06:58:14+00:00".replace("+00:00", "Z"),
+            id="string input with microseconds and Z suffix",
+        ),
     ],
 )
 def test__to_zulu_isoformat_8601__works_as_expected(value: dt.datetime | str, expected_str: str):
     assert to_zulu_isoformat_8601(value) == expected_str
+
+
+def test__to_zulu_isoformat_8601__naive_datetime_error_mode():
+    naive = dt.datetime(2022, 6, 9, 6, 58, 14)
+    with raises(ValueError, match="naive_handling='error'"):
+        to_zulu_isoformat_8601(naive, naive_handling="error")
+
+
+def test__to_zulu_isoformat_8601__naive_datetime_coerce_mode():
+    naive = dt.datetime(2022, 6, 9, 6, 58, 14)
+    assert to_zulu_isoformat_8601(naive, naive_handling="coerce") == "2022-06-09T06:58:14Z"

--- a/test/aibs_informatics_core/utils/test_time.py
+++ b/test/aibs_informatics_core/utils/test_time.py
@@ -2,7 +2,7 @@ import datetime as dt
 
 from pytest import mark, param, raises
 
-from aibs_informatics_core.utils.time import from_isoformat_8601
+from aibs_informatics_core.utils.time import from_isoformat_8601, to_zulu_isoformat_8601
 from test.base import does_not_raise
 
 
@@ -58,3 +58,55 @@ def test__from_isoformat_8601__works_as_expected(
 
     if expected_dt is not None:
         assert actual_dt == expected_dt
+
+
+@mark.parametrize(
+    "value, expected_str",
+    [
+        param(
+            dt.datetime(2022, 6, 9, 6, 58, 14, tzinfo=dt.timezone.utc),
+            "2022-06-09T06:58:14+00:00".replace("+00:00", "Z"),
+            id="UTC datetime",
+        ),
+        param(
+            dt.datetime(2022, 6, 9, 6, 58, 14, 500000, tzinfo=dt.timezone.utc),
+            "2022-06-09T06:58:14.500000+00:00".replace("+00:00", "Z"),
+            id="UTC datetime with microseconds",
+        ),
+        param(
+            dt.datetime(
+                2022,
+                6,
+                9,
+                17,
+                58,
+                14,
+                tzinfo=dt.timezone(dt.timedelta(hours=11)),
+            ),
+            "2022-06-09T06:58:14+00:00".replace("+00:00", "Z"),
+            id="non-UTC datetime converted to Zulu",
+        ),
+        param(
+            "2022-06-09T06:58:14+05:30",
+            "2022-06-09T01:28:14+00:00".replace("+00:00", "Z"),
+            id="string input with +05:30 offset",
+        ),
+        param(
+            "2022-06-09T06:58:14+00:00",
+            "2022-06-09T06:58:14+00:00".replace("+00:00", "Z"),
+            id="string input with +00:00 offset",
+        ),
+        param(
+            "2022-06-09T17:58:14+11:00",
+            "2022-06-09T06:58:14+00:00".replace("+00:00", "Z"),
+            id="string input with non-UTC offset",
+        ),
+        param(
+            "2022-06-09T06:58:14.000+00:00",
+            "2022-06-09T06:58:14+00:00".replace("+00:00", "Z"),
+            id="string input with microseconds and +00:00 offset",
+        ),
+    ],
+)
+def test__to_zulu_isoformat_8601__works_as_expected(value: dt.datetime | str, expected_str: str):
+    assert to_zulu_isoformat_8601(value) == expected_str


### PR DESCRIPTION
## What's in this Change?

Adds a new time utility for normalizing datetimes/ISO-8601 strings into a Zulu (`...Z`) ISO-8601 representation, along with unit tests validating common inputs.

**Changes:**
- Added `to_zulu_isoformat_8601` helper in `aibs_informatics_core.utils.time`.

## Testing

- Added unit tests covering datetime inputs and ISO strings with numeric offsets.

