### PR TITLE
Fix param pair overrides logic to handle list type correctly

### DIFF
--- a/src/aibs_informatics_core/models/demand_execution/parameters.py
+++ b/src/aibs_informatics_core/models/demand_execution/parameters.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from functools import wraps
 from typing import Any
 
@@ -396,14 +396,26 @@ class DemandExecutionParameters(PydanticBaseModel):
             "input_output_pair_overrides",
         ]
 
-        param_pairs = []
+        param_pairs: list[Any] = []
 
-        if in_use_key in data:
-            param_pairs.extend(data.pop(in_use_key))
+        overrides = data.pop(in_use_key, None)
+        if overrides is not None:
+            if not isinstance(overrides, Sequence) or isinstance(overrides, (str, bytes)):
+                raise ValidationError(
+                    f"{in_use_key} must be a sequence of ParamPair or ParamSetPair objects"
+                )
+            param_pairs.extend(overrides)
 
         for k in deprecated_keys:
-            if k in data:
-                param_pairs.extend(data.pop(k))
+            deprecated_overrides = data.pop(k, None)
+            if deprecated_overrides is not None:
+                if not isinstance(deprecated_overrides, Sequence) or isinstance(
+                    deprecated_overrides, (str, bytes)
+                ):
+                    raise ValidationError(
+                        f"{k} must be a sequence of ParamPair or ParamSetPair objects"
+                    )
+                param_pairs.extend(deprecated_overrides)
 
         if param_pairs:
             data[in_use_key] = param_pairs

--- a/test/aibs_informatics_core/models/demand_execution/test_parameters.py
+++ b/test/aibs_informatics_core/models/demand_execution/test_parameters.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from pydantic import ValidationError as PydanticValidationError
 from pytest import fixture, mark, param, raises
 
 from aibs_informatics_core.exceptions import ValidationError
@@ -609,6 +610,50 @@ def test__has_param__works():
     assert parameters.has_param("${HYPENATED_PARAM}")
 
     assert not parameters.has_param("not_a_param")
+
+
+def test__DemandExecutionParameters__init__explicit_param_pair_overrides_handles_Nonetype():
+    parameters = DemandExecutionParameters(
+        params={
+            "param_in1": S3_URI + "1",
+            "param_out1": "foo",
+        },
+        inputs=["param_in1"],
+        outputs=["param_out1"],
+        param_pair_overrides=None,
+        output_s3_prefix=S3_PREFIX,
+    )
+
+    assert parameters.param_pairs == [
+        ParamPair(input="param_in1", output="param_out1"),
+    ]
+
+
+def test__DemandExecutionParameters__init__explicit_param_pair_overrides_raises_for_invalid_type():
+    with raises(PydanticValidationError):
+        DemandExecutionParameters(
+            params={
+                "param_in1": S3_URI + "1",
+                "param_out1": "foo",
+            },
+            inputs=["param_in1"],
+            outputs=["param_out1"],
+            param_pair_overrides="not_a_valid_type",  # type: ignore
+            output_s3_prefix=S3_PREFIX,
+        )
+
+    with raises(PydanticValidationError):
+        DemandExecutionParameters(
+            params={
+                "param_in1": S3_URI + "1",
+                "param_out1": "foo",
+            },
+            inputs=["param_in1"],
+            outputs=["param_out1"],
+            # deprecated key
+            param_pairs="not_a_valid_type",  # type: ignore
+            output_s3_prefix=S3_PREFIX,
+        )
 
 
 def test__get_input_job_param__handles_valid_and_missing():


### PR DESCRIPTION
## What's in this Change?

Fixing some logic that is now causing problems based on the difference in how incoming data does not get pruned anymore. Previously in `SchemaModel` there was a cleanup task that would remove none values. This does not happen now in pydantic. 

So now when you do `DemandExecutionParams(..., param_pair_overrides=None), it will cause errors. 
```
        if in_use_key in data:
>           param_pairs.extend(data.pop(in_use_key))
E           TypeError: 'NoneType' object is not iterabl
```
